### PR TITLE
Update docker-compose.yml

### DIFF
--- a/deploying-fastapi-apps-with-https-powered-by-traefik/app/docker-compose.yml
+++ b/deploying-fastapi-apps-with-https-powered-by-traefik/app/docker-compose.yml
@@ -19,9 +19,6 @@ services:
       - traefik.http.routers.app-https.tls=true
       # Use the "le" (Let's Encrypt) resolver
       - traefik.http.routers.app-https.tls.certresolver=le
-      # https-redirect middleware to redirect HTTP to HTTPS
-      - traefik.http.middlewares.https-redirect.redirectscheme.scheme=https
-      - traefik.http.middlewares.https-redirect.redirectscheme.permanent=true
       # Middleware to redirect HTTP to HTTPS
       - traefik.http.routers.app-http.middlewares=https-redirect
       - traefik.http.routers.app-https.middlewares=admin-auth


### PR DESCRIPTION
Since the middleware is already defined in docker-compose.traefik.yml, those lines in backend service are not needed (as in streamlit and panel services).